### PR TITLE
supastarter 代替 shipfast

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | --- | --- |
 | [smart-excel-ai（免费）](https://github.com/weijunext/smart-excel-ai) | Next.js。集成了登录、支付（lemon squeezy）、AI功能 |
 | [Opensaas（免费）](https://github.com/wasp-lang/open-saas/) | React + Node.js。集成了登录、支付（stripe）、邮件、AI功能 |
-| [Shipfast（付费）](https://shipfa.st/) | Next.js。集成了登录、支付（stripe）、邮件、AI功能 |
+| [SupaStarter（付费）](https://supastarter.dev/)| Next.js/Nuxt.js。集成了登录、支付、邮件、后台 |
 
 ## Chrome 插件开发模板
 


### PR DESCRIPTION
SupaStarter 相比 Shipfast 更好，而且有 nextjs / nuxtjs 两种版本

> @ yucheng chuhailu.club 的评价： shipfast 作者大多精力在营销上，代码质量和更新频率都很差